### PR TITLE
Forceful multi-level redirect to sonce.org

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="sl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Spletno mesto je preseljeno - Sonce</title>
+    <!-- Site closed: redirect to new domain -->
+    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <script>
+        (function() {
+            var target = 'https://www.sonce.org';
+            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+                try {
+                    window.location.replace(target);
+                } catch (e) {
+                    window.location.href = target;
+                }
+            }
+        })();
+    </script>
+</head>
+<body class="bg-white text-gray-800">
+    <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
+        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+    </div>
+    <noscript>
+        <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
+            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+        </div>
+    </noscript>
+    <div style="max-width:720px;margin:32px auto;padding:0 16px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;">
+        <h1 style="font-size:28px;margin-bottom:12px;color:#111;">Stran ni najdena</h1>
+        <p style="color:#444;margin-bottom:16px;">Vsebine, ki jo iščete, ni več na voljo na tem naslovu. Vse naše strani so preseljene na nov naslov.</p>
+        <p><a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">Nadaljujte na sonce.org</a></p>
+    </div>
+</body>
+</html>

--- a/404.html
+++ b/404.html
@@ -5,28 +5,43 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Spletno mesto je preseljeno - Sonce</title>
     <!-- Site closed: redirect to new domain -->
-    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
-    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <meta http-equiv="refresh" content="0;url=https://sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://sonce.org"></noscript>
     <script>
         (function() {
-            var target = 'https://www.sonce.org';
-            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+            var target = 'https://sonce.org';
+            function redirectToTarget() {
                 try {
+                    if (window.top && window.top !== window.self) {
+                        try { window.top.location.replace(target); return; } catch (_) {}
+                        try { window.top.location.href = target; return; } catch (_) {}
+                    }
                     window.location.replace(target);
                 } catch (e) {
-                    window.location.href = target;
+                    try { window.location.href = target; } catch(_) {}
                 }
+            }
+            if (location.hostname !== 'sonce.org' && location.hostname !== 'www.sonce.org') {
+                redirectToTarget();
+                setTimeout(redirectToTarget, 150);
+                setTimeout(redirectToTarget, 1000);
+                window.addEventListener('load', redirectToTarget);
+                document.addEventListener('visibilitychange', function() {
+                    if (document.visibilityState === 'visible') redirectToTarget();
+                }, { once: true });
             }
         })();
     </script>
 </head>
 <body class="bg-white text-gray-800">
     <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
-        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+        Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite gumb:
+        <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:8px 14px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
     </div>
     <noscript>
         <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
-            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+            Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite:
+            <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:6px 12px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
         </div>
     </noscript>
     <div style="max-width:720px;margin:32px auto;padding:0 16px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;">

--- a/index.html
+++ b/index.html
@@ -2354,28 +2354,43 @@
         }
     </script>
     <!-- Site closed: redirect to new domain -->
-    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
-    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <meta http-equiv="refresh" content="0;url=https://sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://sonce.org"></noscript>
     <script>
         (function() {
-            var target = 'https://www.sonce.org';
-            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+            var target = 'https://sonce.org';
+            function redirectToTarget() {
                 try {
+                    if (window.top && window.top !== window.self) {
+                        try { window.top.location.replace(target); return; } catch (_) {}
+                        try { window.top.location.href = target; return; } catch (_) {}
+                    }
                     window.location.replace(target);
                 } catch (e) {
-                    window.location.href = target;
+                    try { window.location.href = target; } catch(_) {}
                 }
+            }
+            if (location.hostname !== 'sonce.org' && location.hostname !== 'www.sonce.org') {
+                redirectToTarget();
+                setTimeout(redirectToTarget, 150);
+                setTimeout(redirectToTarget, 1000);
+                window.addEventListener('load', redirectToTarget);
+                document.addEventListener('visibilitychange', function() {
+                    if (document.visibilityState === 'visible') redirectToTarget();
+                }, { once: true });
             }
         })();
     </script>
 </head>
 <body class="bg-white text-gray-800">
     <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
-        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+        Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite gumb:
+        <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:8px 14px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
     </div>
     <noscript>
         <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
-            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+            Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite:
+            <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:6px 12px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
         </div>
     </noscript>
     <!-- Mobile optimization enabled -->

--- a/index.html
+++ b/index.html
@@ -2353,8 +2353,31 @@
             window.location.href = 'mailto:' + email;
         }
     </script>
+    <!-- Site closed: redirect to new domain -->
+    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <script>
+        (function() {
+            var target = 'https://www.sonce.org';
+            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+                try {
+                    window.location.replace(target);
+                } catch (e) {
+                    window.location.href = target;
+                }
+            }
+        })();
+    </script>
 </head>
 <body class="bg-white text-gray-800">
+    <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
+        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+    </div>
+    <noscript>
+        <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
+            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+        </div>
+    </noscript>
     <!-- Mobile optimization enabled -->
 
     <!-- Mobile warning removed for optimized mobile experience -->

--- a/mobile.html
+++ b/mobile.html
@@ -2334,28 +2334,43 @@
         }
     </script>
     <!-- Site closed: redirect to new domain -->
-    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
-    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <meta http-equiv="refresh" content="0;url=https://sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://sonce.org"></noscript>
     <script>
         (function() {
-            var target = 'https://www.sonce.org';
-            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+            var target = 'https://sonce.org';
+            function redirectToTarget() {
                 try {
+                    if (window.top && window.top !== window.self) {
+                        try { window.top.location.replace(target); return; } catch (_) {}
+                        try { window.top.location.href = target; return; } catch (_) {}
+                    }
                     window.location.replace(target);
                 } catch (e) {
-                    window.location.href = target;
+                    try { window.location.href = target; } catch(_) {}
                 }
+            }
+            if (location.hostname !== 'sonce.org' && location.hostname !== 'www.sonce.org') {
+                redirectToTarget();
+                setTimeout(redirectToTarget, 150);
+                setTimeout(redirectToTarget, 1000);
+                window.addEventListener('load', redirectToTarget);
+                document.addEventListener('visibilitychange', function() {
+                    if (document.visibilityState === 'visible') redirectToTarget();
+                }, { once: true });
             }
         })();
     </script>
 </head>
 <body class="bg-white text-gray-800">
     <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
-        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+        Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite gumb:
+        <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:8px 14px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
     </div>
     <noscript>
         <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
-            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+            Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite:
+            <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:6px 12px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
         </div>
     </noscript>
     <!-- Mobile optimization enabled -->

--- a/mobile.html
+++ b/mobile.html
@@ -2333,8 +2333,31 @@
             window.location.href = 'mailto:' + email;
         }
     </script>
+    <!-- Site closed: redirect to new domain -->
+    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <script>
+        (function() {
+            var target = 'https://www.sonce.org';
+            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+                try {
+                    window.location.replace(target);
+                } catch (e) {
+                    window.location.href = target;
+                }
+            }
+        })();
+    </script>
 </head>
 <body class="bg-white text-gray-800">
+    <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
+        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+    </div>
+    <noscript>
+        <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
+            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+        </div>
+    </noscript>
     <!-- Mobile optimization enabled -->
 
     <!-- Mobile warning removed for optimized mobile experience -->

--- a/pogoji-uporabe.html
+++ b/pogoji-uporabe.html
@@ -7,28 +7,43 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Site closed: redirect to new domain -->
-    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
-    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <meta http-equiv="refresh" content="0;url=https://sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://sonce.org"></noscript>
     <script>
         (function() {
-            var target = 'https://www.sonce.org';
-            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+            var target = 'https://sonce.org';
+            function redirectToTarget() {
                 try {
+                    if (window.top && window.top !== window.self) {
+                        try { window.top.location.replace(target); return; } catch (_) {}
+                        try { window.top.location.href = target; return; } catch (_) {}
+                    }
                     window.location.replace(target);
                 } catch (e) {
-                    window.location.href = target;
+                    try { window.location.href = target; } catch(_) {}
                 }
+            }
+            if (location.hostname !== 'sonce.org' && location.hostname !== 'www.sonce.org') {
+                redirectToTarget();
+                setTimeout(redirectToTarget, 150);
+                setTimeout(redirectToTarget, 1000);
+                window.addEventListener('load', redirectToTarget);
+                document.addEventListener('visibilitychange', function() {
+                    if (document.visibilityState === 'visible') redirectToTarget();
+                }, { once: true });
             }
         })();
     </script>
 </head>
 <body class="bg-gray-50">
     <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
-        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+        Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite gumb:
+        <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:8px 14px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
     </div>
     <noscript>
         <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
-            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+            Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite:
+            <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:6px 12px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
         </div>
     </noscript>
     <div class="container mx-auto px-4 py-12 max-w-4xl">

--- a/pogoji-uporabe.html
+++ b/pogoji-uporabe.html
@@ -6,8 +6,31 @@
     <title>Pogoji uporabe - Pisarna pravne zaščite Sonce Slovenije</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Site closed: redirect to new domain -->
+    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <script>
+        (function() {
+            var target = 'https://www.sonce.org';
+            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+                try {
+                    window.location.replace(target);
+                } catch (e) {
+                    window.location.href = target;
+                }
+            }
+        })();
+    </script>
 </head>
 <body class="bg-gray-50">
+    <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
+        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+    </div>
+    <noscript>
+        <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
+            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+        </div>
+    </noscript>
     <div class="container mx-auto px-4 py-12 max-w-4xl">
         <h1 class="text-3xl font-bold text-primary mb-8">Pogoji uporabe</h1>
         

--- a/pravilnik-o-piskotkih.html
+++ b/pravilnik-o-piskotkih.html
@@ -7,28 +7,43 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Site closed: redirect to new domain -->
-    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
-    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <meta http-equiv="refresh" content="0;url=https://sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://sonce.org"></noscript>
     <script>
         (function() {
-            var target = 'https://www.sonce.org';
-            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+            var target = 'https://sonce.org';
+            function redirectToTarget() {
                 try {
+                    if (window.top && window.top !== window.self) {
+                        try { window.top.location.replace(target); return; } catch (_) {}
+                        try { window.top.location.href = target; return; } catch (_) {}
+                    }
                     window.location.replace(target);
                 } catch (e) {
-                    window.location.href = target;
+                    try { window.location.href = target; } catch(_) {}
                 }
+            }
+            if (location.hostname !== 'sonce.org' && location.hostname !== 'www.sonce.org') {
+                redirectToTarget();
+                setTimeout(redirectToTarget, 150);
+                setTimeout(redirectToTarget, 1000);
+                window.addEventListener('load', redirectToTarget);
+                document.addEventListener('visibilitychange', function() {
+                    if (document.visibilityState === 'visible') redirectToTarget();
+                }, { once: true });
             }
         })();
     </script>
 </head>
 <body class="bg-gray-50">
     <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
-        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+        Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite gumb:
+        <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:8px 14px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
     </div>
     <noscript>
         <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
-            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+            Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite:
+            <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:6px 12px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
         </div>
     </noscript>
     <div class="container mx-auto px-4 py-12 max-w-4xl">

--- a/pravilnik-o-piskotkih.html
+++ b/pravilnik-o-piskotkih.html
@@ -6,8 +6,31 @@
     <title>Pravilnik o piškotkih - Pisarna pravne zaščite Sonce Slovenije</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Site closed: redirect to new domain -->
+    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <script>
+        (function() {
+            var target = 'https://www.sonce.org';
+            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+                try {
+                    window.location.replace(target);
+                } catch (e) {
+                    window.location.href = target;
+                }
+            }
+        })();
+    </script>
 </head>
 <body class="bg-gray-50">
+    <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
+        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+    </div>
+    <noscript>
+        <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
+            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+        </div>
+    </noscript>
     <div class="container mx-auto px-4 py-12 max-w-4xl">
         <h1 class="text-3xl font-bold text-primary mb-8">Pravilnik o piškotkih</h1>
         

--- a/pravilnik-o-zasebnosti.html
+++ b/pravilnik-o-zasebnosti.html
@@ -7,28 +7,43 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- Site closed: redirect to new domain -->
-    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
-    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <meta http-equiv="refresh" content="0;url=https://sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://sonce.org"></noscript>
     <script>
         (function() {
-            var target = 'https://www.sonce.org';
-            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+            var target = 'https://sonce.org';
+            function redirectToTarget() {
                 try {
+                    if (window.top && window.top !== window.self) {
+                        try { window.top.location.replace(target); return; } catch (_) {}
+                        try { window.top.location.href = target; return; } catch (_) {}
+                    }
                     window.location.replace(target);
                 } catch (e) {
-                    window.location.href = target;
+                    try { window.location.href = target; } catch(_) {}
                 }
+            }
+            if (location.hostname !== 'sonce.org' && location.hostname !== 'www.sonce.org') {
+                redirectToTarget();
+                setTimeout(redirectToTarget, 150);
+                setTimeout(redirectToTarget, 1000);
+                window.addEventListener('load', redirectToTarget);
+                document.addEventListener('visibilitychange', function() {
+                    if (document.visibilityState === 'visible') redirectToTarget();
+                }, { once: true });
             }
         })();
     </script>
 </head>
 <body class="bg-gray-50">
     <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
-        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+        Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite gumb:
+        <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:8px 14px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
     </div>
     <noscript>
         <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
-            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+            Naše glavno spletno mesto je <strong>sonce.org</strong>. Če preusmeritev ne deluje, kliknite:
+            <a href="https://sonce.org" style="display:inline-block;margin-left:8px;background:#0d6efd;color:#fff;padding:6px 12px;border-radius:6px;text-decoration:none;font-weight:600;">Odpri sonce.org</a>
         </div>
     </noscript>
     <div class="container mx-auto px-4 py-12 max-w-4xl">

--- a/pravilnik-o-zasebnosti.html
+++ b/pravilnik-o-zasebnosti.html
@@ -6,8 +6,31 @@
     <title>Pravilnik o zasebnosti - Pisarna pravne zaščite Sonce Slovenije</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <!-- Site closed: redirect to new domain -->
+    <meta http-equiv="refresh" content="0;url=https://www.sonce.org">
+    <noscript><meta http-equiv="refresh" content="0;url=https://www.sonce.org"></noscript>
+    <script>
+        (function() {
+            var target = 'https://www.sonce.org';
+            if (window.location.hostname !== 'sonce.org' && window.location.hostname !== 'www.sonce.org') {
+                try {
+                    window.location.replace(target);
+                } catch (e) {
+                    window.location.href = target;
+                }
+            }
+        })();
+    </script>
 </head>
 <body class="bg-gray-50">
+    <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;position:relative;z-index:9999;border-bottom:1px solid #ffe69c;">
+        To spletno mesto je zaprto in preseljeno na <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>. Če preusmeritev ne deluje, kliknite povezavo.
+    </div>
+    <noscript>
+        <div style="background:#fff3cd;color:#664d03;padding:12px 16px;text-align:center;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;border-bottom:1px solid #ffe69c;">
+            To spletno mesto je zaprto. Obiščite <a href="https://www.sonce.org" style="color:#0d6efd;text-decoration:underline;">sonce.org</a>.
+        </div>
+    </noscript>
     <div class="container mx-auto px-4 py-12 max-w-4xl">
         <h1 class="text-3xl font-bold text-primary mb-8">Pravilnik o zasebnosti</h1>
         


### PR DESCRIPTION
Implement multi-layer redirects to `sonce.org` and add a visible site closure notice across all pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-0142c370-cc40-4c92-9f2c-b478ced93769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0142c370-cc40-4c92-9f2c-b478ced93769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

